### PR TITLE
Feature: Auto-save Nextcloud Forms submissions to XLSX #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ chmod +x ./create_windmill_oauth.sh
 7. Подтвердите доступ учеткой Nextcloud и дождитесь возврата в Windmill.
 8. Убедитесь, что в интерфейсе Windmill статус подключения стал `Connected`.
 
+Создание Windmill workflow:
+
+1. Настройте OAuth подключение
+2. На главной странице рядом с кнопкой "+flow" выберите "Import from YAML".
+3. Вставьте содержимое файла windmill_workflow.yaml.
+4. В блок Triggers необходимо добавить NextCloud.
+5. Нажмите Deploy.
+6. Проверьте ещё раз, что Trigger содержит NextCloud
+
+Теперь в панели Runs будут отображаться получаемые запросы, при отправке формы в NextCloud
+
 Проверка сервисов Docker:
 ```bash
 cd playground/onlyoffice-nextcloud/deploy

--- a/playground/onlyoffice-nextcloud/deploy/windmill_workflow.yaml
+++ b/playground/onlyoffice-nextcloud/deploy/windmill_workflow.yaml
@@ -26,9 +26,10 @@ value:
               params = {"format": "json"}
               headers = {"OCS-APIRequest": "true"}
 
-              resp = requests.get(url, auth=auth, headers=headers, params=params)
+              resp = requests.get(url, auth=auth, headers=headers, params=params, timeout=10)
               if resp.status_code != 200:
                   raise Exception(f"Failed to get submissions: {resp.status_code}")
+              print(resp.text)
 
               data = resp.json()
               submissions = data.get("ocs", {}).get("data", {}).get("submissions", [])
@@ -88,6 +89,7 @@ value:
               resp = requests.get(questions_url, auth=auth, headers=headers, params={"format": "json"})
               if resp.status_code != 200:
                   raise Exception(f"Failed to get form questions: {resp.status_code}")
+              print(resp.text)
 
               data = resp.json()
               try:
@@ -98,9 +100,10 @@ value:
               # Скачивание
               path = file_path.lstrip('/')
               download_url = f"{base_url}/remote.php/dav/files/{username}/{path}"
-              resp = requests.get(download_url, auth=auth)
+              resp = requests.get(download_url, auth=auth, timeout=10)
               if resp.status_code != 200:
                   raise Exception(f"Failed to download file: {resp.status_code}")
+              print(resp.text)
 
               # Открытие таблицы
               file_data = BytesIO(resp.content)
@@ -109,6 +112,8 @@ value:
 
               # Следующая свободная строка
               next_row = sheet.max_row + 1
+              while sheet.cell(row=next_row-1, column=1).value is None:
+                  next_row -= 1
 
               # Данные пользователя и времени
               user_id = submission.get("userId", "")
@@ -147,7 +152,7 @@ value:
               output.seek(0)
 
               upload_url = f"{base_url}/remote.php/dav/files/{username}/{path}"
-              put_resp = requests.put(upload_url, data=output, auth=auth,
+              put_resp = requests.put(upload_url, data=output, auth=auth, timeout=10,
                                       headers={"Content-Type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"})
               if put_resp.status_code not in (200, 201, 204):
                   raise Exception(f"Upload failed: {put_resp.status_code}")


### PR DESCRIPTION
После настройки OAuth для начала автоматической записи из форм.
1. Зайти на Windmill
2. В всплывающем меню кнопки "+flow" выбрать Import from YAML
3. Сохранить workflow

Особенности:
Сохранение происходит в таблицу results.xlsx, которую можно поменять.
Сохранение записей в таблице не ломает формулы, но ломает условное форматирование ячеек.
В строку таблицы записывается id пользователя, его отображаемое имя и время заполнения формы.
Порядок вопросов сохраняется.
Для вопросов с несколькими вариантами ответов, ответ записывается в одну ячейку в виде строки.
Проблем при отправке нескольких форм не было замечено, но может нужно более подробное тестирование.
Если выбрать вопрос, который требует ответа в виде файла, то NextCloud создаёт директории с загруженными файлами, но в таблице будет только название файла.